### PR TITLE
Fix build for Windsurf ≥1.12.8: handle appdata/metainfo and icon path changes

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -29,8 +29,24 @@ sha256sums=('d455cc557955a7cf2816b780fa027cc7ef7c347653da8ff183a93ed6405c70f4'
             '5da1525b5fe804b9192c05e1cbf8d751d852e3717fb2787c7ffe98fd5d93e8c1')
 build() {
 	tar -xf "data.tar.xz" --exclude 'usr/share/windsurf/[^r]*' --exclude 'usr/share/windsurf/*.pak'
-	mv usr/share/{appdata,metainfo}
-	mv usr/share/zsh/{vendor-completions,site-functions}
+
+	# Ensure metainfo exists and safely move contents from appdata if present
+	mkdir -p usr/share/metainfo
+	if [ -d usr/share/appdata ]; then
+		shopt -s dotglob nullglob
+		mv usr/share/appdata/* usr/share/metainfo/ || true
+		shopt -u dotglob nullglob
+		rmdir usr/share/appdata 2>/dev/null || true
+	fi
+
+	# Ensure zsh site-functions exists and safely move completions
+	mkdir -p usr/share/zsh/site-functions
+	if [ -d usr/share/zsh/vendor-completions ]; then
+		shopt -s dotglob nullglob
+		mv usr/share/zsh/vendor-completions/* usr/share/zsh/site-functions/ || true
+		shopt -u dotglob nullglob
+		rmdir usr/share/zsh/vendor-completions 2>/dev/null || true
+	fi
 	
 	# Launcher
 	_app=/usr/share/windsurf/resources/app
@@ -40,12 +56,32 @@ build() {
 	ln -sf /usr/bin/windsurf usr/share/windsurf/windsurf
 	
 	# Replacements
+	# Ensure windsurd extension bin path exists for symlinks
+	mkdir -p usr/share/windsurf/resources/app/extensions/windsurf/bin
 	ln -svf /usr/bin/fd usr/share/windsurf/resources/app/extensions/windsurf/bin/fd
 	ln -svf /usr/bin/rg usr/share/windsurf/resources/app/node_modules/@vscode/ripgrep/bin/rg
 	ln -svf /usr/bin/xdg-open usr/share/windsurf/resources/app/node_modules/open/xdg-open
 	
-	# SVG Icon
-	install -Dm644 "usr/share/windsurf/resources/app/out/media/code-icon.svg" "usr/share/icons/hicolor/scalable/apps/windsurf.svg"
+	# SVG Icon (handle path changes across versions)
+	ICON_DEST="usr/share/icons/hicolor/scalable/apps/windsurf.svg"
+	ICON_CANDIDATES=(
+		"usr/share/windsurf/resources/app/out/media/code-icon.svg"
+		"usr/share/windsurf/resources/app/out/media/code-iconsvg.svg"
+		"usr/share/windsurf/resources/app/out/media/windsurf-icon.svg"
+		"usr/share/windsurf/resources/app/out/vs/code/browser/workbench/media/code-icon.svg"
+	)
+	ICON_FOUND=""
+	for icon in "${ICON_CANDIDATES[@]}"; do
+		if [ -f "$icon" ]; then
+			ICON_FOUND="$icon"
+			break
+		fi
+	done
+	if [ -n "$ICON_FOUND" ]; then
+		install -Dm644 "$ICON_FOUND" "$ICON_DEST"
+	else
+		echo "Warning: SVG icon not found in known locations, skipping icon install." >&2
+	fi
 	
 	# Hide entry of URL handler
 	desktop-file-edit --set-key Hidden --set-value true usr/share/applications/windsurf-url-handler.desktop


### PR DESCRIPTION
## Hi there! @xPathin  👋
First of all, thank you so much for sharing and maintaining this package. It has made updating Windsurf incredibly smooth for me, so I wanted to contribute a small fix that keeps things working with the latest `.deb` releases.

## Summary
- Ensure the packaging script keeps working even when the `.deb` layout changes (recent releases rearranged a few directories).
- Make the SVG icon installation resilient so the build succeeds even if the icon moves or gets renamed.

## Changes in `package/PKGBUILD` (`build()` function)
- Create `usr/share/metainfo` and safely move any contents from `usr/share/appdata` (handles the case where `metainfo` already exists).
- Create `usr/share/zsh/site-functions` and safely move any contents from `usr/share/zsh/vendor-completions`.
- Guarantee the path `usr/share/windsurf/resources/app/extensions/windsurf/bin` exists before creating the `fd` symlink.
- Add a friendly SVG icon lookup that checks multiple candidate paths—including the newly observed `usr/share/windsurf/resources/app/out/media/code-iconsvg.svg`—and only issues a warning if no icon is found.

## Issues Resolved
- `mv: cannot overwrite 'usr/share/metainfo/appdata': Directory not empty`
- `install: cannot stat 'usr/share/windsurf/resources/app/out/media/code-icon.svg': No such file or directory`

## Why this approach works
- Relative paths (`usr/...`) operate inside the fakeroot tree during packaging; absolute paths (`/usr/...`) in symlinks ensure they point to the correct binaries after installation.
- The icon lookup is future-proof: if Windsurf relocates or renames the asset again, the build keeps going and simply warns the user.

## Testing
- Environment: Arch Linux x86_64
- Command: `makepkg -sf` run inside `package/`
- Result: Successful build for `pkgver=1.12.8` with SHA256 validation.

## Checklist
- [x] Builds successfully with the latest upstream `.deb`
- [x] Touches only `package/PKGBUILD`
- [x] Compatible with both current and previous `.deb` layouts
- [x] Icon handling no longer breaks the build when missing

## Final note
Thanks again for creating this repo—it really helps me stay up to date with Windsurf. I’m happy to tweak anything in this PR if you’d like a different approach. Looking forward to your feedback!
